### PR TITLE
Minor API updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate selectors;
 extern crate string_cache;
 extern crate typed_arena;
 
-pub use parser::{Html, ParseOpts, IgnoreParseErrors};
+pub use parser::{Html, ParseOpts};
 
 pub mod tree;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate selectors;
 extern crate string_cache;
 extern crate typed_arena;
 
-pub use parser::{parse, ParseOpts};
+pub use parser::{Html, ParseOpts, IgnoreParseErrors};
 
 pub mod tree;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,15 +1,14 @@
-use html5ever::{self, Attribute};
-use html5ever::tree_builder::{TreeSink, NodeOrText, QuirksMode};
 use std::borrow::Cow;
 use std::fs::File;
+use std::io::{Read, Error};
+use std::option;
 use std::path::Path;
-use std::io::Read;
+use html5ever::{self, Attribute};
+use html5ever::tree_builder::{TreeSink, NodeOrText, QuirksMode};
 use string_cache::QualName;
 use typed_arena::Arena;
 
-
 use tree::Node;
-use std::option;
 
 pub struct Html<F = IgnoreParseErrors> where F: FnMut(Cow<'static, str>) {
     opts: ParseOpts<F>,
@@ -17,21 +16,21 @@ pub struct Html<F = IgnoreParseErrors> where F: FnMut(Cow<'static, str>) {
 }
 
 impl Html  {
-    pub fn from_string(string: &str) -> Html {
+    pub fn from_string<S: Into<String>>(string: S) -> Html {
         Html {
             opts: ParseOpts::default(),
-            data: Some(string.to_string()).into_iter(),
+            data: Some(string.into()).into_iter(),
         }
     }
 
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Html {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Html, Error> {
         let mut buf = String::new();
-        let mut file = File::open(&path).unwrap();
+        let mut file = try!(File::open(&path));
         file.read_to_string(&mut buf).unwrap();
-        Html {
+        Ok(Html {
             opts: ParseOpts::default(),
             data: Some(buf).into_iter(),
-        }
+        })
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,35 +1,63 @@
 use html5ever::{self, Attribute};
 use html5ever::tree_builder::{TreeSink, NodeOrText, QuirksMode};
 use std::borrow::Cow;
+use std::fs::File;
+use std::path::Path;
+use std::io::Read;
 use string_cache::QualName;
 use typed_arena::Arena;
 
+
 use tree::Node;
+use std::option;
 
-
-pub fn parse<'a, F, I>(source: I, arena: &'a Arena<Node<'a>>, opts: ParseOpts<F>) -> &'a Node<'a>
-                       where I: IntoIterator<Item=String>, F: FnMut(Cow<'static, str>) {
-    let parser = Parser {
-        arena: arena,
-        document_node: Node::new_document(arena),
-        on_parse_error: opts.on_parse_error,
-    };
-    let opts = html5ever::ParseOpts {
-        tokenizer: opts.tokenizer,
-        tree_builder: opts.tree_builder,
-    };
-    let parser = html5ever::parse_to(parser, source.into_iter(), opts);
-    parser.document_node
+pub struct Html<F = IgnoreParseErrors> where F: FnMut(Cow<'static, str>) {
+    opts: ParseOpts<F>,
+    data: option::IntoIter<String>,
 }
 
+impl Html  {
+    pub fn from_string(string: &str) -> Html {
+        Html {
+            opts: ParseOpts::default(),
+            data: Some(string.to_string()).into_iter(),
+        }
+    }
 
-pub struct ParseOpts<F> where F: FnMut(Cow<'static, str>) {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Html {
+        let mut buf = String::new();
+        let mut file = File::open(&path).unwrap();
+        file.read_to_string(&mut buf).unwrap();
+        Html {
+            opts: ParseOpts::default(),
+            data: Some(buf).into_iter(),
+        }
+    }
+}
+
+impl<F> Html <F> where F: FnMut(Cow<'static, str>) {
+    pub fn parse<'a>(self, arena: &'a Arena<Node<'a>>) -> &'a Node<'a> {
+        let parser = Parser {
+            arena : arena,
+            document_node: Node::new_document(arena),
+            on_parse_error: self.opts.on_parse_error,
+        };
+        let html5opts = html5ever::ParseOpts {
+            tokenizer: self.opts.tokenizer,
+            tree_builder: self.opts.tree_builder,
+        };
+        let parser = html5ever::parse_to(parser, self.data, html5opts);
+        parser.document_node
+    }
+}
+
+pub struct ParseOpts<F =IgnoreParseErrors> where F: FnMut(Cow<'static, str>) {
     pub tokenizer: html5ever::tokenizer::TokenizerOpts,
     pub tree_builder: html5ever::tree_builder::TreeBuilderOpts,
     pub on_parse_error: F,
 }
 
-struct IgnoreParseErrors;
+pub struct IgnoreParseErrors;
 
 impl<Args> FnOnce<Args> for IgnoreParseErrors {
     type Output = ();

--- a/src/select.rs
+++ b/src/select.rs
@@ -48,12 +48,13 @@ impl<'a> TNode<'a> for &'a Node<'a> {
     unsafe fn set_dirty_descendants(self, _value: bool) { unimplemented!() }
 }
 
+
 impl<'a> TElement<'a> for &'a ElementData {
     fn get_local_name(self) -> &'a Atom { &self.name.local }
     fn get_namespace(self) -> &'a Namespace { &self.name.ns }
     fn get_hover_state(self) -> bool { false }
     fn get_focus_state(self) -> bool { false }
-    fn get_id(self) -> Option<Atom> { 
+    fn get_id(self) -> Option<Atom> {
         self.attributes.borrow().get(&QualName::new(ns!(""), atom!(id))).map(|s| Atom::from_slice(s))
     }
     fn get_disabled_state(self) -> bool { false }
@@ -61,7 +62,7 @@ impl<'a> TElement<'a> for &'a ElementData {
     fn get_checked_state(self) -> bool { false }
     fn get_indeterminate_state(self) -> bool { false }
     fn has_class(self, name: &Atom) -> bool {
-        !name.is_empty() && 
+        !name.is_empty() &&
         if let Some(class_attr) = self.attributes.borrow().get(&QualName::new(ns!(""), atom!(class))) {
             class_attr.split(::selectors::matching::SELECTOR_WHITESPACE)
             .any(|class| name.as_slice() == class )
@@ -71,7 +72,7 @@ impl<'a> TElement<'a> for &'a ElementData {
     }
     fn has_nonzero_border(self) -> bool { false }
     fn is_link(self) -> bool {
-        self.name.ns == ns!(html) && 
+        self.name.ns == ns!(html) &&
         matches!(self.name.local, atom!(a) | atom!(area) | atom!(link)) &&
         self.attributes.borrow().contains_key(&QualName::new(ns!(""), atom!(href)))
     }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,7 @@
-use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize};
-use html5ever::serialize::TraversalScope::*;
 use std::io::{Write, Result};
 use std::string::ToString;
+use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize};
+use html5ever::serialize::TraversalScope::*;
 
 use tree::{Node, NodeData};
 
@@ -48,14 +48,8 @@ impl<'a> Serializable for Node<'a> {
 
 impl<'a> ToString for Node<'a> {
     fn to_string(&self) -> String {
-        let mut utf_vec = Vec::new();
-        let result = match serialize(&mut utf_vec, self, Default::default()) {
-            Ok(_) => match String::from_utf8(utf_vec)  {
-                Ok(s) => s,
-                Err(_) => String::new(),
-            },
-            Err(_) => String::new(),
-        };
-        result
+        let mut u8_vec = Vec::new();
+        serialize(&mut u8_vec, self, Default::default()).unwrap();
+        String::from_utf8(u8_vec).unwrap()
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,6 +1,7 @@
-use html5ever::serialize::{Serializable, Serializer, TraversalScope};
+use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize};
 use html5ever::serialize::TraversalScope::*;
 use std::io::{Write, Result};
+use std::string::ToString;
 
 use tree::{Node, NodeData};
 
@@ -41,5 +42,20 @@ impl<'a> Serializable for Node<'a> {
 
             (IncludeNode, &NodeData::Document(_)) => panic!("Can't serialize Document node itself"),
         }
+    }
+}
+
+
+impl<'a> ToString for Node<'a> {
+    fn to_string(&self) -> String {
+        let mut utf_vec = Vec::new();
+        let result = match serialize(&mut utf_vec, self, Default::default()) {
+            Ok(_) => match String::from_utf8(utf_vec)  {
+                Ok(s) => s,
+                Err(_) => String::new(),
+            },
+            Err(_) => String::new(),
+        };
+        result
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,7 @@
-use html5ever::serialize::serialize;
 use html5ever::tree_builder::QuirksMode;
 use selectors::tree::TNode;
 use typed_arena::Arena;
 use super::{Html};
-
 
 #[test]
 fn parse_and_serialize() {
@@ -14,9 +12,7 @@ fn parse_and_serialize() {
 <p>Content";
     let document = Html::from_string(html).parse(&arena);
     assert_eq!(document.as_document().unwrap().quirks_mode(), QuirksMode::NoQuirks);
-    let mut serialized = Vec::new();
-    serialize(&mut serialized, document, Default::default()).unwrap();
-    assert_eq!(String::from_utf8(serialized).unwrap(), r"<!DOCTYPE html>
+    assert_eq!(document.to_string(), r"<!DOCTYPE html>
 <html><head><title>Test case</title>
 </head><body><p>Content</p></body></html>");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,11 +26,9 @@ fn select() {
 <p class=foo>Foo
 <p>Bar
 ";
+
     let document = Html::from_string(html).parse(&arena);
-    let selectors = ::selectors::parser::parse_author_origin_selector_list_from_str("p.foo").unwrap();
-    let matching = document.descendants()
-    .filter(|node| node.is_element() && ::selectors::matching::matches(&selectors, node, &None))
-    .collect::<Vec<_>>();
+    let matching = document.css("p.foo").collect::<Vec<_>>();
     assert_eq!(matching.len(), 1);
     assert_eq!(&**matching[0].first_child().unwrap().as_text().unwrap().borrow(), "Foo\n");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use html5ever::tree_builder::QuirksMode;
 use selectors::tree::TNode;
 use typed_arena::Arena;
 use std::path::Path;
+
 use super::{Html};
 
 #[test]
@@ -34,7 +35,7 @@ fn parse_file() {
     
 
 </body></html>";
-    let document = Html::from_file(&path).parse(&arena);
+    let document = Html::from_file(&path).unwrap().parse(&arena);
     assert_eq!(document.to_string(), html);
 }
 
@@ -48,7 +49,7 @@ fn select() {
 ";
 
     let document = Html::from_string(html).parse(&arena);
-    let matching = document.css("p.foo").collect::<Vec<_>>();
+    let matching = document.select("p.foo").unwrap().collect::<Vec<_>>();
     assert_eq!(matching.len(), 1);
     assert_eq!(&**matching[0].first_child().unwrap().as_text().unwrap().borrow(), "Foo\n");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use html5ever::tree_builder::QuirksMode;
 use selectors::tree::TNode;
 use typed_arena::Arena;
+use std::path::Path;
 use super::{Html};
 
 #[test]
@@ -17,6 +18,25 @@ fn parse_and_serialize() {
 </head><body><p>Content</p></body></html>");
 }
 
+#[test]
+fn parse_file() {
+    let arena = Arena::new();
+    let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
+    path.push("test_data".to_string());
+    path.push("foo.html");
+
+    let html = r"<!DOCTYPE html>
+<html><head>
+        <title>Test case</title>
+    </head>
+    <body>
+        <p>Foo</p>
+    
+
+</body></html>";
+    let document = Html::from_file(&path).parse(&arena);
+    assert_eq!(document.to_string(), html);
+}
 
 #[test]
 fn select() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use html5ever::serialize::serialize;
 use html5ever::tree_builder::QuirksMode;
 use selectors::tree::TNode;
 use typed_arena::Arena;
+use super::{Html};
 
 
 #[test]
@@ -11,7 +12,7 @@ fn parse_and_serialize() {
 <!doctype html>
 <title>Test case</title>
 <p>Content";
-    let document = ::parse(Some(html.into()), &arena, Default::default());
+    let document = Html::from_string(html).parse(&arena);
     assert_eq!(document.as_document().unwrap().quirks_mode(), QuirksMode::NoQuirks);
     let mut serialized = Vec::new();
     serialize(&mut serialized, document, Default::default()).unwrap();
@@ -29,7 +30,7 @@ fn select() {
 <p class=foo>Foo
 <p>Bar
 ";
-    let document = ::parse(Some(html.into()), &arena, Default::default());
+    let document = Html::from_string(html).parse(&arena);
     let selectors = ::selectors::parser::parse_author_origin_selector_list_from_str("p.foo").unwrap();
     let matching = document.descendants()
     .filter(|node| node.is_element() && ::selectors::matching::matches(&selectors, node, &None))

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,8 +1,8 @@
-use html5ever::tree_builder::QuirksMode;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::fmt;
 use std::iter::Rev;
+use html5ever::tree_builder::QuirksMode;
 use string_cache::QualName;
 use typed_arena::Arena;
 

--- a/test_data/foo.html
+++ b/test_data/foo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test case</title>
+    </head>
+    <body>
+        <p>Foo</p>
+    </body>
+</html>


### PR DESCRIPTION
Decided to add some convenience API for following things:
### Parsing

It's tedious to write: 

``` rust
     ::parse(Some(html.into()), &arena, Default::default());
```

   Also looking at [Nokogiri](http://www.nokogiri.org/tutorials/parsing_an_html_xml_document.html) it uses Html/Xml to differentiate parsers. I assume a similar API would be nice so I propose following syntax:

``` rust
     Html::from_string(html).parse(&arena);
```

So basically I separated creating/parsing into two parts and absorbed Default into `from_string`. First you construct an object from string `Html::from_string(html)` and then your add arena and it will parse.  I think this solution will allow to more easily change internal representation (i.e. what if we change tree to something that doesn't require an arena).
### Input functions

For convenience  I've added `from_string`, `from_file` methods to kuchiki, idea is that people can just pass a path to retrieve and parse a file. Possible future improvements - integrate hyper to retrieve a HTML page or XML file and parse it.
### Serialization

I provided `ToString` implementation for `Node<'a>`, which will allow any node to be serialized with a simple `node.to_string()`, instead of writing out:

``` rust
    let mut serialized = Vec::new();
    serialize(&mut serialized, document, Default::default()).unwrap();
    assert_eq!(String::from_utf8(serialized).unwrap(), r"<!DOCTYPE html>");
    assert_eq!(document.to_string(), r"<!DOCTYPE html>...");
```
### Selectors

I added a `css` method to `Node<'a>` which will filter all descendants of said node and return an iterator, for further processing. It's a convenience method for replacing:

``` rust
    let document = ::parse(Some(html.into()), &arena, Default::default());
    let selectors = ::selectors::parser::parse_author_origin_selector_list_from_str("p.foo").unwrap();
    let matching = document.descendants()
       .filter(|node| node.is_element() && ::selectors::matching::matches(&selectors, node, &None))
       .collect::<Vec<_>>();
```

with following

``` rust
    let document = Html::from_string(html).parse(&arena);
    let matching = document.css("p.foo").collect::<Vec<_>>();
```
