### PR TITLE
Actually iterate over each node with Node::select()

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -112,13 +112,12 @@ impl<'a,T> Iterator for FilterNodes<T> where T: Iterator<Item=&'a Node<'a>> {
 
     #[inline]
     fn next(&mut self) -> Option<&'a Node<'a>> {
-        let mut next_node = None;
         for node in self.iter.by_ref() {
             if node.is_element() && matching::matches(&self.filter, &node, &None) {
-                next_node = Some(node)
+                return Some(node)
             }
         }
-        next_node
+        None
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,10 +46,11 @@ fn select() {
 <title>Test case</title>
 <p class=foo>Foo
 <p>Bar
+<p class=foo>Foo
 ";
 
     let document = Html::from_string(html).parse(&arena);
     let matching = document.select("p.foo").unwrap().collect::<Vec<_>>();
-    assert_eq!(matching.len(), 1);
+    assert_eq!(matching.len(), 2);
     assert_eq!(&**matching[0].first_child().unwrap().as_text().unwrap().borrow(), "Foo\n");
 }


### PR DESCRIPTION
I was looking forward to use this API change, thanks for the great work! I tried to use node.select, but I spoted a rather obvious bug: it only yields the last matching node. This is because the iterator `next` method is iterating on all values of the internal iterator rather than returning the values.

Here is patch to fix this.
