### PR TITLE
Include the node itself when serializing with to_string

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,6 +1,6 @@
 use std::io::{Write, Result};
 use std::string::ToString;
-use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize};
+use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize, SerializeOpts};
 use html5ever::serialize::TraversalScope::*;
 
 use tree::{Node, NodeData};
@@ -49,7 +49,16 @@ impl<'a> Serializable for Node<'a> {
 impl<'a> ToString for Node<'a> {
     fn to_string(&self) -> String {
         let mut u8_vec = Vec::new();
-        serialize(&mut u8_vec, self, Default::default()).unwrap();
+
+        let traversal_scope = match self.data {
+            NodeData::Document(_) => ChildrenOnly,
+            _ => IncludeNode,
+        };
+
+        serialize(&mut u8_vec, self, SerializeOpts {
+            traversal_scope: traversal_scope,
+            ..Default::default()
+        }).unwrap();
         String::from_utf8(u8_vec).unwrap()
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -54,3 +54,20 @@ fn select() {
     assert_eq!(matching.len(), 2);
     assert_eq!(&**matching[0].first_child().unwrap().as_text().unwrap().borrow(), "Foo\n");
 }
+
+#[test]
+fn to_string() {
+    let arena = Arena::new();
+    let html = r"<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test case</title>
+    </head>
+    <body>
+        <p class=foo>Foo
+    </body>
+</html>";
+
+    let document = Html::from_string(html).parse(&arena);
+    assert_eq!(document.descendants().nth(11).unwrap().to_string(), "<p class=\"foo\">Foo\n    \n</p>");
+}


### PR DESCRIPTION
Calling `node.to_string` does not display the node itself, only its content. Displaying the node would be more useful in my opinion. I was printing an empty element and a text data and was confused why nothing was printed, as both nodes did not have any child to print.
