### PR TITLE
Add text iteration over children

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::iter::FilterMap;
+
 use selectors::parser;
 use selectors::matching;
 use selectors::tree::{TNode, TElement};
@@ -101,6 +104,12 @@ impl<'a> Node<'a> {
         })
     }
 
+    pub fn text_iter(&'a self) -> FilterMap<Descendants<'a>, fn(&'a Node)-> Option<&'a RefCell<String>>> {
+        fn filter_text<'b>(node: &'b Node) -> Option<&'b RefCell<String>> {
+            node.as_text()
+        }
+        self.descendants().filter_map(filter_text)
+    }
 }
 
 pub struct SelectNodes<T> {

--- a/src/select.rs
+++ b/src/select.rs
@@ -93,21 +93,22 @@ impl<'a> TElement<'a> for &'a ElementData {
 }
 
 impl<'a> Node<'a> {
-    pub fn select(&'a self, css_str: &str) -> Result<FilterNodes<Descendants<'a>>, ()> {
+    pub fn select(&'a self, css_str: &str) -> Result<SelectNodes<Descendants<'a>>, ()> {
         let selectors = try!(parser::parse_author_origin_selector_list_from_str(css_str));
-        Ok(FilterNodes{
+        Ok(SelectNodes{
             iter: self.descendants(),
             filter: selectors,
         })
     }
+
 }
 
-pub struct FilterNodes<T> {
+pub struct SelectNodes<T> {
     iter: T,
     filter: Vec<Selector>,
 }
 
-impl<'a,T> Iterator for FilterNodes<T> where T: Iterator<Item=&'a Node<'a>> {
+impl<'a,T> Iterator for SelectNodes<T> where T: Iterator<Item=&'a Node<'a>> {
     type Item = &'a Node<'a>;
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,30 @@ use std::path::Path;
 use super::{Html};
 
 #[test]
+fn text_iter() {
+    let arena = Arena::new();
+    let html = r"
+<!doctype html>
+<title>Test case</title>
+<p>Content contains <b>Important</b> data</p>";
+    let document = Html::from_string(html).parse(&arena);
+    let paragraph = document.select("p").unwrap().collect::<Vec<_>>();
+    assert_eq!(paragraph.len(), 1);
+    let texts = paragraph[0].text_iter().collect::<Vec<_>>();
+    println!("{:?}", texts);
+    assert_eq!(texts.len(), 3);
+    assert_eq!(&*texts[0].borrow(), "Content contains ");
+    assert_eq!(&*texts[1].borrow(), "Important");
+    assert_eq!(&*texts[2].borrow(), " data");
+    {
+        let mut x = texts[0].borrow_mut();
+        &x.truncate(0);
+        &x.push_str("Content doesn't contain ");
+    }
+    assert_eq!(&*texts[0].borrow(), "Content doesn't contain ");
+}
+
+#[test]
 fn parse_and_serialize() {
     let arena = Arena::new();
     let html = r"


### PR DESCRIPTION
By calling `node.text_iter()` you get `Ref<'a, String>` of all children that are text nodes. Using this Iterator allows you to bypass the `as_text` cast and `is_text` check, but it requires you to iterate over content.

Should I add a mutable version that returns `RefCell`?
