### PR TITLE
Switch to reference counting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ matches = "0.1.2"
 html5ever = "0.1"
 string_cache = "0.1"
 string_cache_plugin = "0.1"
-rcref = "0.1"
 
 [dependencies.selectors]
 git = "https://github.com/servo/rust-selectors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ name = "kuchiki"
 doctest = false
 
 [dependencies]
-typed-arena = "1.0"
+movecell = "0.1.1"
 matches = "0.1.2"
 html5ever = "0.1"
 string_cache = "0.1"
 string_cache_plugin = "0.1"
+rcref = "0.1"
 
 [dependencies.selectors]
 git = "https://github.com/servo/rust-selectors"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 extern crate html5ever;
 #[macro_use] extern crate matches;
 extern crate movecell;
-extern crate rcref;
 extern crate selectors;
 extern crate string_cache;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
-#![feature(unboxed_closures, core, plugin)]
+#![feature(unboxed_closures, core, plugin, alloc)]
 #![plugin(string_cache_plugin)]
 
 extern crate html5ever;
 #[macro_use] extern crate matches;
+extern crate movecell;
+extern crate rcref;
 extern crate selectors;
 extern crate string_cache;
-extern crate typed_arena;
 
 pub use parser::{Html, ParseOpts};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(unboxed_closures, core, plugin, alloc)]
+#![feature(unboxed_closures, core, plugin, rc_weak)]
 #![plugin(string_cache_plugin)]
 
 extern crate html5ever;

--- a/src/select.rs
+++ b/src/select.rs
@@ -40,18 +40,6 @@ impl TNode for NodeRef {
     fn is_html_element_in_html_document(&self) -> bool {
         matches!(self.data, NodeData::Element(ref element) if element.name.ns == ns!(html))
     }
-
-    fn has_changed(&self) -> bool { unimplemented!() }
-    unsafe fn set_changed(&self, _value: bool) { unimplemented!() }
-
-    fn is_dirty(&self) -> bool { unimplemented!() }
-    unsafe fn set_dirty(&self, _value: bool) { unimplemented!() }
-
-    fn has_dirty_siblings(&self) -> bool { unimplemented!() }
-    unsafe fn set_dirty_siblings(&self, _value: bool) { unimplemented!() }
-
-    fn has_dirty_descendants(&self) -> bool { unimplemented!() }
-    unsafe fn set_dirty_descendants(&self, _value: bool) { unimplemented!() }
 }
 
 
@@ -76,7 +64,6 @@ impl TElement for NodeDataRef<ElementData> {
             false
         }
     }
-    fn has_nonzero_border(&self) -> bool { false }
     fn is_link(&self) -> bool {
         self.name.ns == ns!(html) &&
         matches!(self.name.local, atom!(a) | atom!(area) | atom!(link)) &&

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,33 +1,34 @@
 use std::cell::RefCell;
 use std::iter::FilterMap;
 
+use rcref::RcRef;
 use selectors::parser;
 use selectors::matching;
 use selectors::tree::{TNode, TElement};
 use selectors::parser::{AttrSelector, NamespaceConstraint, Selector};
 use string_cache::{Atom, Namespace, QualName};
 
-use tree::{Node, NodeData, ElementData, Descendants};
+use tree::{Node, NodeRef, NodeData, ElementData, Descendants};
 
 
-impl<'a> TNode<'a> for &'a Node<'a> {
+impl<'a> TNode<'a> for NodeRef {
     type Element = &'a ElementData;
 
-    fn parent_node(self) -> Option<Self> { self.parent() }
-    fn first_child(self) -> Option<Self> { self.first_child() }
-    fn last_child(self) -> Option<Self> { self.last_child() }
-    fn prev_sibling(self) -> Option<Self> { self.previous_sibling() }
-    fn next_sibling(self) -> Option<Self> { self.next_sibling() }
-    fn is_document(self) -> bool { matches!(self.data, NodeData::Document(_)) }
-    fn is_element(self) -> bool { matches!(self.data, NodeData::Element(_)) }
-    fn as_element(self) -> &'a ElementData { self.as_element().unwrap() }
-    fn match_attr<F>(self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool {
+    fn parent_node(&self) -> Option<Self> { Node::parent(self) }
+    fn first_child(&self) -> Option<Self> { Node::first_child(self) }
+    fn last_child(&self) -> Option<Self> { Node::last_child(self) }
+    fn prev_sibling(&self) -> Option<Self> { Node::previous_sibling(self) }
+    fn next_sibling(&self) -> Option<Self> { Node::next_sibling(self) }
+    fn is_document(&self) -> bool { matches!(self.data, NodeData::Document(_)) }
+    fn is_element(&self) -> bool { matches!(self.data, NodeData::Element(_)) }
+    fn as_element(&'a self) -> &'a ElementData { Node::as_element(self).unwrap() }
+    fn match_attr<F>(&self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool {
         let name = if self.is_html_element_in_html_document() {
             &attr.lower_name
         } else {
             &attr.name
         };
-        if let Some(element) = self.as_element() {
+        if let Some(element) = Node::as_element(self) {
             element.attributes.borrow().iter().any(|(key, value)| {
                 !matches!(attr.namespace, NamespaceConstraint::Specific(ref ns) if *ns != key.ns) &&
                 key.local == *name &&
@@ -37,37 +38,37 @@ impl<'a> TNode<'a> for &'a Node<'a> {
             false
         }
     }
-    fn is_html_element_in_html_document(self) -> bool {
+    fn is_html_element_in_html_document(&self) -> bool {
         matches!(self.data, NodeData::Element(ref element) if element.name.ns == ns!(html))
     }
 
-    fn has_changed(self) -> bool { unimplemented!() }
-    unsafe fn set_changed(self, _value: bool) { unimplemented!() }
+    fn has_changed(&self) -> bool { unimplemented!() }
+    unsafe fn set_changed(&self, _value: bool) { unimplemented!() }
 
-    fn is_dirty(self) -> bool { unimplemented!() }
-    unsafe fn set_dirty(self, _value: bool) { unimplemented!() }
+    fn is_dirty(&self) -> bool { unimplemented!() }
+    unsafe fn set_dirty(&self, _value: bool) { unimplemented!() }
 
-    fn has_dirty_siblings(self) -> bool { unimplemented!() }
-    unsafe fn set_dirty_siblings(self, _value: bool) { unimplemented!() }
+    fn has_dirty_siblings(&self) -> bool { unimplemented!() }
+    unsafe fn set_dirty_siblings(&self, _value: bool) { unimplemented!() }
 
-    fn has_dirty_descendants(self) -> bool { unimplemented!() }
-    unsafe fn set_dirty_descendants(self, _value: bool) { unimplemented!() }
+    fn has_dirty_descendants(&self) -> bool { unimplemented!() }
+    unsafe fn set_dirty_descendants(&self, _value: bool) { unimplemented!() }
 }
 
 
-impl<'a> TElement<'a> for &'a ElementData {
-    fn get_local_name(self) -> &'a Atom { &self.name.local }
-    fn get_namespace(self) -> &'a Namespace { &self.name.ns }
-    fn get_hover_state(self) -> bool { false }
-    fn get_focus_state(self) -> bool { false }
-    fn get_id(self) -> Option<Atom> {
+impl<'b> TElement for &'b ElementData {
+    fn get_local_name<'a>(&'a self) -> &'a Atom { &self.name.local }
+    fn get_namespace<'a>(&'a self) -> &'a Namespace { &self.name.ns }
+    fn get_hover_state(&self) -> bool { false }
+    fn get_focus_state(&self) -> bool { false }
+    fn get_id(&self) -> Option<Atom> {
         self.attributes.borrow().get(&QualName::new(ns!(""), atom!(id))).map(|s| Atom::from_slice(s))
     }
-    fn get_disabled_state(self) -> bool { false }
-    fn get_enabled_state(self) -> bool { false }
-    fn get_checked_state(self) -> bool { false }
-    fn get_indeterminate_state(self) -> bool { false }
-    fn has_class(self, name: &Atom) -> bool {
+    fn get_disabled_state(&self) -> bool { false }
+    fn get_enabled_state(&self) -> bool { false }
+    fn get_checked_state(&self) -> bool { false }
+    fn get_indeterminate_state(&self) -> bool { false }
+    fn has_class(&self, name: &Atom) -> bool {
         !name.is_empty() &&
         if let Some(class_attr) = self.attributes.borrow().get(&QualName::new(ns!(""), atom!(class))) {
             class_attr.split(::selectors::matching::SELECTOR_WHITESPACE)
@@ -76,15 +77,15 @@ impl<'a> TElement<'a> for &'a ElementData {
             false
         }
     }
-    fn has_nonzero_border(self) -> bool { false }
-    fn is_link(self) -> bool {
+    fn has_nonzero_border(&self) -> bool { false }
+    fn is_link(&self) -> bool {
         self.name.ns == ns!(html) &&
         matches!(self.name.local, atom!(a) | atom!(area) | atom!(link)) &&
         self.attributes.borrow().contains_key(&QualName::new(ns!(""), atom!(href)))
     }
-    fn is_visited_link(self) -> bool { false }
-    fn is_unvisited_link(self) -> bool { self.is_link() }
-    fn each_class<F>(self, mut callback: F) where F: FnMut(&Atom) {
+    fn is_visited_link(&self) -> bool { false }
+    fn is_unvisited_link(&self) -> bool { self.is_link() }
+    fn each_class<F>(&self, mut callback: F) where F: FnMut(&Atom) {
         if let Some(class_attr) = self.attributes.borrow().get(&QualName::new(ns!(""), atom!(class))) {
             for class in class_attr.split(::selectors::matching::SELECTOR_WHITESPACE) {
                 if !class.is_empty() {
@@ -95,8 +96,8 @@ impl<'a> TElement<'a> for &'a ElementData {
     }
 }
 
-impl<'a> Node<'a> {
-    pub fn select(&'a self, css_str: &str) -> Result<SelectNodes<Descendants<'a>>, ()> {
+impl NodeRef {
+    pub fn select(&self, css_str: &str) -> Result<SelectNodes<Descendants>, ()> {
         let selectors = try!(parser::parse_author_origin_selector_list_from_str(css_str));
         Ok(SelectNodes{
             iter: self.descendants(),
@@ -104,11 +105,8 @@ impl<'a> Node<'a> {
         })
     }
 
-    pub fn text_iter(&'a self) -> FilterMap<Descendants<'a>, fn(&'a Node)-> Option<&'a RefCell<String>>> {
-        fn filter_text<'b>(node: &'b Node) -> Option<&'b RefCell<String>> {
-            node.as_text()
-        }
-        self.descendants().filter_map(filter_text)
+    pub fn text_iter<'a>(&self) -> FilterMap<Descendants, fn(NodeRef)-> Option<RcRef<Node, RefCell<String>>>> {
+        self.descendants().filter_map(NodeRef::as_text_ref)
     }
 }
 
@@ -117,11 +115,11 @@ pub struct SelectNodes<T> {
     filter: Vec<Selector>,
 }
 
-impl<'a,T> Iterator for SelectNodes<T> where T: Iterator<Item=&'a Node<'a>> {
-    type Item = &'a Node<'a>;
+impl<'a,T> Iterator for SelectNodes<T> where T: Iterator<Item=NodeRef> {
+    type Item = NodeRef;
 
     #[inline]
-    fn next(&mut self) -> Option<&'a Node<'a>> {
+    fn next(&mut self) -> Option<NodeRef> {
         for node in self.iter.by_ref() {
             if node.is_element() && matching::matches(&self.filter, &node, &None) {
                 return Some(node)

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,10 +3,10 @@ use std::string::ToString;
 use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize, SerializeOpts};
 use html5ever::serialize::TraversalScope::*;
 
-use tree::{Node, NodeData};
+use tree::{NodeRef, NodeData};
 
 
-impl<'a> Serializable for Node<'a> {
+impl Serializable for NodeRef {
     fn serialize<'wr, Wr: Write>(&self, serializer: &mut Serializer<'wr, Wr>,
                                  traversal_scope: TraversalScope) -> Result<()> {
         match (traversal_scope, &self.data) {
@@ -46,7 +46,7 @@ impl<'a> Serializable for Node<'a> {
 }
 
 
-impl<'a> ToString for Node<'a> {
+impl ToString for NodeRef {
     fn to_string(&self) -> String {
         let mut u8_vec = Vec::new();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,22 +1,19 @@
 use html5ever::tree_builder::QuirksMode;
 use selectors::tree::TNode;
-use typed_arena::Arena;
 use std::path::Path;
 
 use super::{Html};
 
 #[test]
 fn text_iter() {
-    let arena = Arena::new();
     let html = r"
 <!doctype html>
 <title>Test case</title>
 <p>Content contains <b>Important</b> data</p>";
-    let document = Html::from_string(html).parse(&arena);
+    let document = Html::from_string(html).parse();
     let paragraph = document.select("p").unwrap().collect::<Vec<_>>();
     assert_eq!(paragraph.len(), 1);
     let texts = paragraph[0].text_iter().collect::<Vec<_>>();
-    println!("{:?}", texts);
     assert_eq!(texts.len(), 3);
     assert_eq!(&*texts[0].borrow(), "Content contains ");
     assert_eq!(&*texts[1].borrow(), "Important");
@@ -31,12 +28,11 @@ fn text_iter() {
 
 #[test]
 fn parse_and_serialize() {
-    let arena = Arena::new();
     let html = r"
 <!doctype html>
 <title>Test case</title>
 <p>Content";
-    let document = Html::from_string(html).parse(&arena);
+    let document = Html::from_string(html).parse();
     assert_eq!(document.as_document().unwrap().quirks_mode(), QuirksMode::NoQuirks);
     assert_eq!(document.to_string(), r"<!DOCTYPE html>
 <html><head><title>Test case</title>
@@ -45,7 +41,6 @@ fn parse_and_serialize() {
 
 #[test]
 fn parse_file() {
-    let arena = Arena::new();
     let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
     path.push("test_data".to_string());
     path.push("foo.html");
@@ -59,13 +54,12 @@ fn parse_file() {
     
 
 </body></html>";
-    let document = Html::from_file(&path).unwrap().parse(&arena);
+    let document = Html::from_file(&path).unwrap().parse();
     assert_eq!(document.to_string(), html);
 }
 
 #[test]
 fn select() {
-    let arena = Arena::new();
     let html = r"
 <title>Test case</title>
 <p class=foo>Foo
@@ -73,15 +67,15 @@ fn select() {
 <p class=foo>Foo
 ";
 
-    let document = Html::from_string(html).parse(&arena);
+    let document = Html::from_string(html).parse();
     let matching = document.select("p.foo").unwrap().collect::<Vec<_>>();
     assert_eq!(matching.len(), 2);
-    assert_eq!(&**matching[0].first_child().unwrap().as_text().unwrap().borrow(), "Foo\n");
+    let child = matching[0].first_child().unwrap();
+    assert_eq!(&**child.as_text().unwrap().borrow(), "Foo\n");
 }
 
 #[test]
 fn to_string() {
-    let arena = Arena::new();
     let html = r"<!DOCTYPE html>
 <html>
     <head>
@@ -92,6 +86,6 @@ fn to_string() {
     </body>
 </html>";
 
-    let document = Html::from_string(html).parse(&arena);
+    let document = Html::from_string(html).parse();
     assert_eq!(document.descendants().nth(11).unwrap().to_string(), "<p class=\"foo\">Foo\n    \n</p>");
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2,9 +2,12 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::fmt;
 use std::iter::Rev;
+use std::ops::Deref;
+use std::rc::{Rc, Weak};
 use html5ever::tree_builder::QuirksMode;
+use movecell::MoveCell;
+use rcref::RcRef;
 use string_cache::QualName;
-use typed_arena::Arena;
 
 
 #[derive(Debug, PartialEq, Clone)]
@@ -40,89 +43,83 @@ impl DocumentData {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct NodeRef(pub Rc<Node>);
+
+impl Deref for NodeRef {
+    type Target = Node;
+    fn deref(&self) -> &Node { &*self.0 }
+}
+
 /// A node inside a DOM-like tree.
-pub struct Node<'a> {
-    parent: Cell<Option<&'a Node<'a>>>,
-    previous_sibling: Cell<Option<&'a Node<'a>>>,
-    next_sibling: Cell<Option<&'a Node<'a>>>,
-    first_child: Cell<Option<&'a Node<'a>>>,
-    last_child: Cell<Option<&'a Node<'a>>>,
+pub struct Node {
+    parent: MoveCell<Option<Weak<Node>>>,
+    previous_sibling: MoveCell<Option<Weak<Node>>>,
+    next_sibling: MoveCell<Option<Rc<Node>>>,
+    first_child: MoveCell<Option<Rc<Node>>>,
+    last_child: MoveCell<Option<Weak<Node>>>,
     pub data: NodeData,
 }
 
-
-impl<'a> Eq for Node<'a> {}
-impl<'a> PartialEq for Node<'a> {
-    fn eq(&self, other: &Node<'a>) -> bool {
+impl Eq for Node {}
+impl PartialEq for Node {
+    fn eq(&self, other: &Node) -> bool {
         self as *const Node == other as *const Node
     }
 }
 
-impl<'a> fmt::Debug for Node<'a> {
+impl fmt::Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{:?} @ {:?}", self.data, self as *const Node)
     }
 }
 
-trait Take<T> {
-    fn take(&self) -> Option<T>;
-}
-
-impl<T: Copy> Take<T> for Cell<Option<T>> {
-    fn take(&self) -> Option<T> {
-        let value = self.get();
-        self.set(None);
-        value
-    }
-}
-
-impl<'a> Node<'a> {
+impl NodeRef {
     /// Create a new node from its associated data.
-    pub fn new(data: NodeData, arena: &'a Arena<Node<'a>>) -> &'a Node<'a> {
-        arena.alloc(Node {
-            parent: Cell::new(None),
-            first_child: Cell::new(None),
-            last_child: Cell::new(None),
-            previous_sibling: Cell::new(None),
-            next_sibling: Cell::new(None),
+    pub fn new(data: NodeData) -> NodeRef {
+        NodeRef(Rc::new(Node {
+            parent: MoveCell::new(None),
+            first_child: MoveCell::new(None),
+            last_child: MoveCell::new(None),
+            previous_sibling: MoveCell::new(None),
+            next_sibling: MoveCell::new(None),
             data: data,
-        })
+        }))
     }
 
-    pub fn new_element<I>(name: QualName, attributes: I, arena: &'a Arena<Node<'a>>)
-                          -> &'a Node<'a>
+    pub fn new_element<I>(name: QualName, attributes: I) -> NodeRef
                           where I: IntoIterator<Item=(QualName, String)> {
-        Node::new(NodeData::Element(ElementData {
+        NodeRef::new(NodeData::Element(ElementData {
             name: name,
             attributes: RefCell::new(attributes.into_iter().collect()),
-        }), arena)
+        }))
     }
 
-    pub fn new_text<T: Into<String>>(value: T, arena: &'a Arena<Node<'a>>) -> &'a Node<'a> {
-        Node::new(NodeData::Text(RefCell::new(value.into())), arena)
+    pub fn new_text<T: Into<String>>(value: T) -> NodeRef {
+        NodeRef::new(NodeData::Text(RefCell::new(value.into())))
     }
 
-    pub fn new_comment<T: Into<String>>(value: T, arena: &'a Arena<Node<'a>>) -> &'a Node<'a> {
-        Node::new(NodeData::Comment(RefCell::new(value.into())), arena)
+    pub fn new_comment<T: Into<String>>(value: T) -> NodeRef {
+        NodeRef::new(NodeData::Comment(RefCell::new(value.into())))
     }
 
-    pub fn new_doctype<T1, T2, T3>(name: T1, public_id: T2, system_id: T3,
-                                   arena: &'a Arena<Node<'a>>)
-                                   -> &'a Node<'a>
+    pub fn new_doctype<T1, T2, T3>(name: T1, public_id: T2, system_id: T3) -> NodeRef
                                    where T1: Into<String>, T2: Into<String>, T3: Into<String> {
-        Node::new(NodeData::Doctype(Doctype {
+        NodeRef::new(NodeData::Doctype(Doctype {
             name: name.into(),
             public_id: public_id.into(),
             system_id: system_id.into(),
-        }), arena)
+        }))
     }
 
-    pub fn new_document(arena: &'a Arena<Node<'a>>) -> &'a Node<'a> {
-        Node::new(NodeData::Document(DocumentData {
+    pub fn new_document() -> NodeRef {
+        NodeRef::new(NodeData::Document(DocumentData {
             _quirks_mode: Cell::new(QuirksMode::NoQuirks),
-        }), arena)
+        }))
     }
+}
 
+impl Node {
     pub fn as_element(&self) -> Option<&ElementData> {
         match self.data {
             NodeData::Element(ref value) => Some(value),
@@ -159,50 +156,72 @@ impl<'a> Node<'a> {
     }
 
     /// Return a reference to the parent node, unless this node is the root of the tree.
-    pub fn parent(&self) -> Option<&'a Node<'a>> {
-        self.parent.get()
+    pub fn parent(&self) -> Option<NodeRef> {
+        self.parent.and_then(|weak| weak.upgrade()).map(NodeRef)
     }
 
     /// Return a reference to the first child of this node, unless it has no child.
-    pub fn first_child(&self) -> Option<&'a Node<'a>> {
-        self.first_child.get()
+    pub fn first_child(&self) -> Option<NodeRef> {
+        self.first_child.clone_inner().map(NodeRef)
     }
 
     /// Return a reference to the last child of this node, unless it has no child.
-    pub fn last_child(&self) -> Option<&'a Node<'a>> {
-        self.last_child.get()
+    pub fn last_child(&self) -> Option<NodeRef> {
+        self.last_child.and_then(|weak| weak.upgrade()).map(NodeRef)
     }
 
     /// Return a reference to the previous sibling of this node, unless it is a first child.
-    pub fn previous_sibling(&self) -> Option<&'a Node<'a>> {
-        self.previous_sibling.get()
+    pub fn previous_sibling(&self) -> Option<NodeRef> {
+        self.previous_sibling.and_then(|weak| weak.upgrade()).map(NodeRef)
     }
 
     /// Return a reference to the previous sibling of this node, unless it is a last child.
-    pub fn next_sibling(&self) -> Option<&'a Node<'a>> {
-        self.next_sibling.get()
+    pub fn next_sibling(&self) -> Option<NodeRef> {
+        self.next_sibling.clone_inner().map(NodeRef)
+    }
+}
+
+impl NodeRef {
+    pub fn as_element_ref(self) -> Option<RcRef<Node, ElementData>> {
+        RcRef::new_opt(self.0, Node::as_element)
+    }
+
+    pub fn as_text_ref(self) -> Option<RcRef<Node, RefCell<String>>> {
+        RcRef::new_opt(self.0, Node::as_text)
+    }
+
+    pub fn as_comment_ref(self) -> Option<RcRef<Node, RefCell<String>>> {
+        RcRef::new_opt(self.0, Node::as_comment)
+    }
+
+    pub fn as_doctype_ref(self) -> Option<RcRef<Node, Doctype>> {
+        RcRef::new_opt(self.0, Node::as_doctype)
+    }
+
+    pub fn as_document_ref(self) -> Option<RcRef<Node, DocumentData>> {
+        RcRef::new_opt(self.0, Node::as_document)
     }
 
     /// Return an iterator of references to this node and its ancestors.
     ///
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
-    pub fn ancestors(&'a self) -> Ancestors<'a> {
-        Ancestors(Some(self))
+    pub fn ancestors(&self) -> Ancestors {
+        Ancestors(Some(self.clone()))
     }
 
     /// Return an iterator of references to this node and the siblings before it.
     ///
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
-    pub fn preceding_siblings(&'a self) -> Rev<Siblings<'a>> {
+    pub fn preceding_siblings(&self) -> Rev<Siblings> {
         match self.parent() {
             Some(parent) => {
                 let first_sibling = parent.first_child().unwrap();
-                debug_assert!(self.previous_sibling().is_some() || self == first_sibling);
-                Siblings(Some(State { next: first_sibling, next_back: self }))
+                debug_assert!(self.previous_sibling().is_some() || *self == first_sibling);
+                Siblings(Some(State { next: first_sibling, next_back: self.clone() }))
             }
             None => {
                 debug_assert!(self.previous_sibling().is_none());
-                Siblings(Some(State { next: self, next_back: self }))
+                Siblings(Some(State { next: self.clone(), next_back: self.clone() }))
             }
         }.rev()
     }
@@ -210,22 +229,22 @@ impl<'a> Node<'a> {
     /// Return an iterator of references to this node and the siblings after it.
     ///
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
-    pub fn following_siblings(&'a self) -> Siblings<'a> {
+    pub fn following_siblings(&self) -> Siblings {
         match self.parent() {
             Some(parent) => {
                 let last_sibling = parent.last_child().unwrap();
-                debug_assert!(self.next_sibling().is_some() || self == last_sibling);
-                Siblings(Some(State { next: self, next_back: last_sibling }))
+                debug_assert!(self.next_sibling().is_some() || *self == last_sibling);
+                Siblings(Some(State { next: self.clone(), next_back: last_sibling }))
             }
             None => {
                 debug_assert!(self.next_sibling().is_none());
-                Siblings(Some(State { next: self, next_back: self }))
+                Siblings(Some(State { next: self.clone(), next_back: self.clone() }))
             }
         }
     }
 
     /// Return an iterator of references to this node’s children.
-    pub fn children(&self) -> Siblings<'a> {
+    pub fn children(&self) -> Siblings {
         match (self.first_child(), self.last_child()) {
             (Some(first_child), Some(last_child)) => {
                 Siblings(Some(State { next: first_child, next_back: last_child }))
@@ -241,100 +260,118 @@ impl<'a> Node<'a> {
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
     ///
     /// Note: this is the `NodeEdge::Start` items from `traverse()`.
-    pub fn descendants(&'a self) -> Descendants<'a> {
+    pub fn descendants(&self) -> Descendants {
         Descendants(self.traverse())
     }
 
     /// Return an iterator of the start and end edges of this node and its descendants,
     /// in tree order.
-    pub fn traverse(&'a self) -> Traverse<'a> {
-        Traverse(Some(State { next: NodeEdge::Start(self), next_back: NodeEdge::End(self) }))
+    pub fn traverse(&self) -> Traverse {
+        Traverse(Some(State {
+            next: NodeEdge::Start(self.clone()),
+            next_back: NodeEdge::End(self.clone())
+        }))
     }
+}
 
+impl Node {
     /// Detach a node from its parent and siblings. Children are not affected.
     pub fn detach(&self) {
-        let parent = self.parent.take();
-        let previous_sibling = self.previous_sibling.take();
-        let next_sibling = self.next_sibling.take();
+        let parent_weak = self.parent.take();
+        let previous_sibling_weak = self.previous_sibling.take();
+        let next_sibling_strong = self.next_sibling.take();
 
-        if let Some(next_sibling) = next_sibling {
-            next_sibling.previous_sibling.set(previous_sibling);
-        } else if let Some(parent) = parent {
-            parent.last_child.set(previous_sibling);
+        let previous_sibling_opt = previous_sibling_weak.as_ref().and_then(|weak| weak.upgrade());
+
+        if let Some(next_sibling_ref) = next_sibling_strong.as_ref() {
+            next_sibling_ref.previous_sibling.replace(previous_sibling_weak);
+        } else if let Some(parent_ref) = parent_weak.as_ref() {
+            if let Some(parent_strong) = parent_ref.upgrade() {
+                parent_strong.last_child.replace(previous_sibling_weak);
+            }
         }
 
-        if let Some(previous_sibling) = previous_sibling {
-            previous_sibling.next_sibling.set(next_sibling);
-        } else if let Some(parent) = parent {
-            parent.first_child.set(next_sibling);
+        if let Some(previous_sibling_strong) = previous_sibling_opt {
+            previous_sibling_strong.next_sibling.replace(next_sibling_strong);
+        } else if let Some(parent_ref) = parent_weak.as_ref() {
+            if let Some(parent_strong) = parent_ref.upgrade() {
+                parent_strong.first_child.replace(next_sibling_strong);
+            }
         }
     }
+}
 
+impl NodeRef {
     /// Append a new child to this node, after existing children.
-    pub fn append(&'a self, new_child: &'a Node<'a>) {
+    pub fn append(&self, new_child: NodeRef) {
         new_child.detach();
-        new_child.parent.set(Some(self));
-        if let Some(last_child) = self.last_child.take() {
-            new_child.previous_sibling.set(Some(last_child));
-            debug_assert!(last_child.next_sibling().is_none());
-            last_child.next_sibling.set(Some(new_child));
-        } else {
-            debug_assert!(self.first_child().is_none());
-            self.first_child.set(Some(new_child));
+        new_child.parent.replace(Some(self.0.downgrade()));
+        if let Some(last_child_weak) = self.last_child.replace(Some(new_child.0.downgrade())) {
+            if let Some(last_child) = last_child_weak.upgrade() {
+                new_child.previous_sibling.replace(Some(last_child_weak));
+                debug_assert!(last_child.next_sibling.is_none());
+                last_child.next_sibling.replace(Some(new_child.0));
+                return
+            }
         }
-        self.last_child.set(Some(new_child));
+        debug_assert!(self.first_child.is_none());
+        self.first_child.replace(Some(new_child.0));
     }
 
     /// Prepend a new child to this node, before existing children.
-    pub fn prepend(&'a self, new_child: &'a Node<'a>) {
+    pub fn prepend(&self, new_child: NodeRef) {
         new_child.detach();
-        new_child.parent.set(Some(self));
+        new_child.parent.replace(Some(self.0.downgrade()));
         if let Some(first_child) = self.first_child.take() {
-            debug_assert!(first_child.previous_sibling().is_none());
-            first_child.previous_sibling.set(Some(new_child));
-            new_child.next_sibling.set(Some(first_child));
+            debug_assert!(first_child.previous_sibling.is_none());
+            first_child.previous_sibling.replace(Some(new_child.0.downgrade()));
+            new_child.next_sibling.replace(Some(first_child));
         } else {
-            debug_assert!(self.first_child().is_none());
-            self.last_child.set(Some(new_child));
+            debug_assert!(self.first_child.is_none());
+            self.last_child.replace(Some(new_child.0.downgrade()));
         }
-        self.first_child.set(Some(new_child));
+        self.first_child.replace(Some(new_child.0));
     }
 
     /// Insert a new sibling after this node.
-    pub fn insert_after(&'a self, new_sibling: &'a Node<'a>) {
+    pub fn insert_after(&self, new_sibling: NodeRef) {
         new_sibling.detach();
-        new_sibling.parent.set(self.parent());
-        new_sibling.previous_sibling.set(Some(self));
+        new_sibling.parent.replace(self.parent.clone_inner());
+        new_sibling.previous_sibling.replace(Some(self.0.downgrade()));
         if let Some(next_sibling) = self.next_sibling.take() {
-            debug_assert!(next_sibling.previous_sibling().unwrap() == self);
-            next_sibling.previous_sibling.set(Some(new_sibling));
-            new_sibling.next_sibling.set(Some(next_sibling));
+            debug_assert!(next_sibling.previous_sibling().unwrap() == *self);
+            next_sibling.previous_sibling.replace(Some(new_sibling.0.downgrade()));
+            new_sibling.next_sibling.replace(Some(next_sibling));
         } else if let Some(parent) = self.parent() {
-            debug_assert!(parent.last_child().unwrap() == self);
-            parent.last_child.set(Some(new_sibling));
+            debug_assert!(parent.last_child().unwrap() == *self);
+            parent.last_child.replace(Some(new_sibling.0.downgrade()));
         }
-        self.next_sibling.set(Some(new_sibling));
+        self.next_sibling.replace(Some(new_sibling.0));
     }
 
     /// Insert a new sibling before this node.
-    pub fn insert_before(&'a self, new_sibling: &'a Node<'a>) {
+    pub fn insert_before(&self, new_sibling: NodeRef) {
         new_sibling.detach();
-        new_sibling.parent.set(self.parent());
-        new_sibling.next_sibling.set(Some(self));
-        if let Some(previous_sibling) = self.previous_sibling.take() {
-            new_sibling.previous_sibling.set(Some(previous_sibling));
-            debug_assert!(previous_sibling.next_sibling().unwrap() == self);
-            previous_sibling.next_sibling.set(Some(new_sibling));
-        } else if let Some(parent) = self.parent() {
-            debug_assert!(parent.first_child().unwrap() == self);
-            parent.first_child.set(Some(new_sibling));
+        new_sibling.parent.replace(self.parent.clone_inner());
+        new_sibling.next_sibling.replace(Some(self.0.clone()));
+        if let Some(previous_sibling_weak) = self.previous_sibling.replace(
+                Some(new_sibling.0.downgrade())) {
+            if let Some(previous_sibling) = previous_sibling_weak.upgrade() {
+                new_sibling.previous_sibling.replace(Some(previous_sibling_weak));
+                debug_assert!(previous_sibling.next_sibling().unwrap() == *self);
+                previous_sibling.next_sibling.replace(Some(new_sibling.0));
+                return
+            }
         }
-        self.previous_sibling.set(Some(new_sibling));
+        if let Some(parent) = self.parent() {
+            debug_assert!(parent.first_child().unwrap() == *self);
+            parent.first_child.replace(Some(new_sibling.0));
+        }
     }
 }
 
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 struct State<T> {
     next: T,
     next_back: T,
@@ -342,44 +379,44 @@ struct State<T> {
 
 
 /// A double-ended iterator of sibling nodes.
-#[derive(Debug, Clone, Copy)]
-pub struct Siblings<'a>(Option<State<&'a Node<'a>>>);
+#[derive(Debug, Clone)]
+pub struct Siblings(Option<State<NodeRef>>);
 
 macro_rules! siblings_next {
-    ($next: ident, $next_sibling: ident) => {
-        fn $next(&mut self) -> Option<&'a Node<'a>> {
-            self.0.map(|state| {
-                self.0 = match state.$next.$next_sibling() {
-                    Some(sibling) if state.next != state.next_back => {
-                        Some(State { $next: sibling, ..state })
+    ($next: ident, $next_back: ident, $next_sibling: ident) => {
+        fn $next(&mut self) -> Option<NodeRef> {
+            #![allow(non_shorthand_field_patterns)]
+            self.0.take().map(|State { $next: next, $next_back: next_back }| {
+                if let Some(sibling) = next.$next_sibling() {
+                    if next != next_back {
+                        self.0 = Some(State { $next: sibling, $next_back: next_back })
                     }
-                    _ => None
-                };
-                state.$next
+                }
+                next
             })
         }
     }
 }
 
-impl<'a> Iterator for Siblings<'a> {
-    type Item = &'a Node<'a>;
-    siblings_next!(next, next_sibling);
+impl Iterator for Siblings {
+    type Item = NodeRef;
+    siblings_next!(next, next_back, next_sibling);
 }
 
-impl<'a> DoubleEndedIterator for Siblings<'a> {
-    siblings_next!(next_back, previous_sibling);
+impl DoubleEndedIterator for Siblings {
+    siblings_next!(next_back, next, previous_sibling);
 }
 
 
 /// An iterator on ancestor nodes.
-#[derive(Debug, Clone, Copy)]
-pub struct Ancestors<'a>(Option<&'a Node<'a>>);
+#[derive(Debug, Clone)]
+pub struct Ancestors(Option<NodeRef>);
 
-impl<'a> Iterator for Ancestors<'a> {
-    type Item = &'a Node<'a>;
+impl Iterator for Ancestors {
+    type Item = NodeRef;
 
-    fn next(&mut self) -> Option<&'a Node<'a>> {
-        self.0.map(|node| {
+    fn next(&mut self) -> Option<NodeRef> {
+        self.0.take().map(|node| {
             self.0 = node.parent();
             node
         })
@@ -388,12 +425,12 @@ impl<'a> Iterator for Ancestors<'a> {
 
 
 /// An iterator of references to a given node and its descendants, in tree order.
-#[derive(Debug, Clone, Copy)]
-pub struct Descendants<'a>(Traverse<'a>);
+#[derive(Debug, Clone)]
+pub struct Descendants(Traverse);
 
 macro_rules! descendants_next {
     ($next: ident) => {
-        fn $next(&mut self) -> Option<&'a Node<'a>> {
+        fn $next(&mut self) -> Option<NodeRef> {
             loop {
                 match (self.0).$next() {
                     Some(NodeEdge::Start(node)) => return Some(node),
@@ -405,12 +442,12 @@ macro_rules! descendants_next {
     }
 }
 
-impl<'a> Iterator for Descendants<'a> {
-    type Item = &'a Node<'a>;
+impl Iterator for Descendants {
+    type Item = NodeRef;
     descendants_next!(next);
 }
 
-impl<'a> DoubleEndedIterator for Descendants<'a> {
+impl DoubleEndedIterator for Descendants {
     descendants_next!(next_back);
 }
 
@@ -430,49 +467,47 @@ pub enum NodeEdge<T> {
 
 
 /// An iterator of the start and end edges of the nodes in a given subtree.
-#[derive(Debug, Clone, Copy)]
-pub struct Traverse<'a>(Option<State<NodeEdge<&'a Node<'a>>>>);
+#[derive(Debug, Clone)]
+pub struct Traverse(Option<State<NodeEdge<NodeRef>>>);
 
 macro_rules! traverse_next {
-    ($next: ident, $first_child: ident, $next_sibling: ident, $Start: ident, $End: ident) => {
-        fn $next(&mut self) -> Option<NodeEdge<&'a Node<'a>>> {
-            self.0.map(|state| {
-                self.0 = if state.next == state.next_back {
-                    None
-                } else {
-                    match state.$next {
-                        NodeEdge::$Start(node) => {
+    ($next: ident, $next_back: ident, $first_child: ident, $next_sibling: ident, $Start: ident, $End: ident) => {
+        fn $next(&mut self) -> Option<NodeEdge<NodeRef>> {
+            #![allow(non_shorthand_field_patterns)]
+            self.0.take().map(|State { $next: next, $next_back: next_back }| {
+                if next != next_back {
+                    self.0 = match next {
+                        NodeEdge::$Start(ref node) => {
                             match node.$first_child() {
                                 Some(child) => {
-                                    Some(State { $next: NodeEdge::$Start(child), ..state })
+                                    Some(State { $next: NodeEdge::$Start(child), $next_back: next_back })
                                 }
-                                None => Some(State { $next: NodeEdge::$End(node), ..state })
+                                None => Some(State { $next: NodeEdge::$End(node.clone()), $next_back: next_back })
                             }
                         }
-                        NodeEdge::$End(node) => {
+                        NodeEdge::$End(ref node) => {
                             match node.$next_sibling() {
                                 Some(sibling) => {
-                                    Some(State { $next: NodeEdge::$Start(sibling), ..state })
+                                    Some(State { $next: NodeEdge::$Start(sibling), $next_back: next_back })
                                 }
                                 None => node.parent().map(|parent| {
-                                    State { $next: NodeEdge::$End(parent), ..state }
+                                    State { $next: NodeEdge::$End(parent), $next_back: next_back }
                                 })
                             }
                         }
-                    }
-                };
-                state.$next
+                    };
+                }
+                next
             })
         }
     }
 }
 
-impl<'a> Iterator for Traverse<'a> {
-    type Item = NodeEdge<&'a Node<'a>>;
-    traverse_next!(next, first_child, next_sibling, Start, End);
+impl Iterator for Traverse {
+    type Item = NodeEdge<NodeRef>;
+    traverse_next!(next, next_back, first_child, next_sibling, Start, End);
 }
 
-impl<'a> DoubleEndedIterator for Traverse<'a> {
-    traverse_next!(next_back, last_child, previous_sibling, End, Start);
-
+impl DoubleEndedIterator for Traverse {
+    traverse_next!(next_back, next, last_child, previous_sibling, End, Start);
 }


### PR DESCRIPTION
After some [tree experiments](https://github.com/SimonSapin/rust-forest) I had decided against reference-counting since tree access (e.g. iterating nodes in a subtree) requires incrementing/decrementing reference counts, which is probably a performance hit. I went with an arena allocator instead.

But API ergonomics of the arena allocator are not great, and there is no evidence that the performance hit of reference-counting is actually significant in practice. Also, the use cases for Kuchiki are probably not as performance-critical as Servo.

This PR switches Kuchiki back to reference counting. To avoid leaks through reference cycles, pointers to parent, previous sibling, and last child nodes are weak references. This means that only holding a strong reference (`NodeRef`) to a single node will keep the subtree and following siblings alive, but not preceding siblings, ancestors, or their respective subtrees.

This depends on https://github.com/servo/rust-selectors/pull/30.

@Ygg01, what do you think?
