### PR TITLE
Add initial support for writing Nodes into files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,8 @@ string_cache = "0.1"
 string_cache_plugin = "0.1"
 tendril = "0.1.1"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [dependencies.selectors]
 git = "https://github.com/servo/rust-selectors"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate movecell;
 extern crate selectors;
 extern crate string_cache;
 extern crate tendril;
+#[cfg(test)] extern crate tempdir;
 
 pub use parser::{Html, ParseOpts};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,9 +34,7 @@ impl Html  {
             }))).into_iter(),
         })
     }
-}
 
-impl Html {
     pub fn parse(self) -> NodeRef {
         let parser = Parser {
             document_node: NodeRef::new_document(),
@@ -49,6 +47,7 @@ impl Html {
         let parser = html5ever::parse_to(parser, self.data, html5opts);
         parser.document_node
     }
+
 }
 
 #[derive(Default)]

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,4 +1,6 @@
+use std::fs::File;
 use std::io::{Write, Result};
+use std::path::Path;
 use std::string::ToString;
 use html5ever::serialize::{Serializable, Serializer, TraversalScope, serialize, SerializeOpts};
 use html5ever::serialize::TraversalScope::*;
@@ -58,5 +60,10 @@ impl NodeRef {
             traversal_scope: IncludeNode,
             ..Default::default()
         })
+    }
+
+    pub fn serialize_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()>{
+        let mut file = try!(File::create(&path));
+        self.serialize(&mut file)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use html5ever::tree_builder::QuirksMode;
 use selectors::tree::TNode;
 use std::path::Path;
 
+use tempdir::TempDir;
 use super::{Html};
 
 #[test]
@@ -56,6 +57,20 @@ fn parse_file() {
 </body></html>";
     let document = Html::from_file(&path).unwrap().parse();
     assert_eq!(document.to_string(), html);
+}
+
+#[test]
+fn serialize_and_read_file() {
+    let tempdir = TempDir::new("test_rm_tempdir").unwrap();
+    let mut path = tempdir.path().to_path_buf();
+    path.push("temp.html");
+
+    let html = r"<!DOCTYPE html><html><head><title>Title</title></head><body>Body</body></html>";
+    let document = Html::from_string(html).parse();
+    let _ = document.serialize_to_file(path.clone());
+
+    let document2 = Html::from_file(&path).unwrap().parse();
+    assert_eq!(document.to_string(), document2.to_string());
 }
 
 #[test]


### PR DESCRIPTION
This is the most rudimentary form of support for writing nodes/documents into files.

It takes current `to_string()` method and writes it into a newly created file. This is probably horrible performance wise. If file can't be created or written it returns `io::Error`.

Future improvements could include some other customization options, like finer granularity writing method (`char`, `byte`, `&str`, etc. (See [this RFC](https://github.com/rust-lang/rfcs/blob/ff6283a6f3507ac51957e9471a697781c7e60c2d/active/0000-text-streams.md) for further inspiration).
