### PR TITLE
Add example of Kuchiki parsing a page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ rc = "0.1.0"
 
 [dev-dependencies]
 tempdir = "0.3"
+hyper = "0.6"

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -1,0 +1,34 @@
+extern crate hyper;
+extern crate kuchiki;
+
+use hyper::Client;
+
+use kuchiki::Html;
+
+fn main() {
+    // Create a client.
+    let client = Client::new();
+    let url = "https://www.mozilla.org/en-US/";
+    println!("{} - {} ", "Calling site ", url);
+
+    // Get response
+    let mut response = client.get(url).send().unwrap();
+
+    // Parse the html page
+    if let Ok(html) = Html::from_stream(&mut response) {
+        println!("{}", "Finding Easter egg");
+        let doc = html.parse();
+
+        // Manually navigate to hidden comment
+        let x = doc.children().nth(1).unwrap()
+                    .first_child().unwrap()
+                    .children().nth(3).unwrap();
+
+        // Convert comment into RefString and borrow it
+        let comment = x.as_comment().unwrap().borrow();
+
+        println!("{}", *comment);
+    } else {
+        println!("{}", "The page couldn't be parsed");
+    }
+}


### PR DESCRIPTION
This is a small stand-alone example that describes how to get
a page, parse it and print one content of a node (in this case a Mozilla Easter
egg).

I've ran into a small issue (see #13 ). Also it might be prudent to wire up tests so that even examples are tested, to prevent code rot.
