### PR TITLE
Implement tree::Element::get_target_state from rust-selectors

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -9,6 +9,10 @@ use node_data_ref::NodeDataRef;
 
 impl selectors::Element for NodeDataRef<ElementData> {
     #[inline]
+    fn get_target_state(&self) -> bool {
+        false
+    }
+    #[inline]
     fn parent_element(&self) -> Option<Self> {
         self.as_node().parent().and_then(NodeRef::into_element_ref)
     }


### PR DESCRIPTION
This fixes the following build error:

> cargo build
>    Compiling kuchiki v0.1.0 (file:///Users/a_/dev/kuchiki)
> src/select.rs:10:1: 106:2 error: not all trait items implemented, missing: `get_target_state` [E0046]
> src/select.rs:10 impl selectors::Element for NodeDataRef<ElementData> {
> src/select.rs:11     #[inline]
> src/select.rs:12     fn parent_element(&self) -> Option<Self> {
> src/select.rs:13         self.as_node().parent().and_then(NodeRef::into_element_ref)
> src/select.rs:14     }
> src/select.rs:15     #[inline]
>                  ...
> src/select.rs:10:1: 106:2 help: run `rustc --explain E0046` to see a detailed explanation
> error: aborting due to previous error
> Could not compile `kuchiki`.

I'm not sure of the function's purpose. So, I've made the implementation always return `false`.
