### PR TITLE
re-export the custom parse function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod tree;
 
 pub use attributes::Attributes;
 pub use node_data_ref::NodeDataRef;
-pub use parser::{parse_html, ParseOpts};
+pub use parser::{parse_html, parse_html_with_options, ParseOpts};
 pub use select::Selectors;
 pub use tree::{NodeRef, Node, NodeData, ElementData, Doctype, DocumentData};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,7 +23,7 @@ pub fn parse_html() -> html5ever::Parser<Sink> {
     parse_html_with_options(ParseOpts::default())
 }
 
-/// Parse an HTML document with html5ever.
+/// Parse an HTML document with html5ever with custom configuration.
 pub fn parse_html_with_options(opts: ParseOpts) -> html5ever::Parser<Sink> {
     let sink = Sink {
         document_node: NodeRef::new_document(),


### PR DESCRIPTION
I'd like to use kuchiki with custom parse options. 