### PR TITLE
Remove the `cargo doc` CI command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --features unstable)
   - cargo test
   - cargo test --features hyper
-  - cargo doc --features hyper
+  - cargo build


### PR DESCRIPTION
There's really no point in generating the docs here. The syntax of the docs is already known to be correct,
because of how Markdown and Rust's doc attributes both work, and the docs are hosted on docs.rs now.