### PR TITLE
Update html5ever to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 cssparser = "0.13"
 matches = "0.1.4"
-html5ever = "0.18"
+html5ever = "0.20"
 selectors = "0.18"
 
 [dev-dependencies]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -167,4 +167,14 @@ impl TreeSink for Sink {
     fn get_template_contents(&mut self, target: &NodeRef) -> NodeRef {
         target.as_element().unwrap().template_contents.clone().unwrap()
     }
+
+    fn append_based_on_parent_node(
+        &mut self,
+        _element: &NodeRef,
+        _prev_element: &NodeRef,
+        _child: NodeOrText<NodeRef>,
+    ) {
+        // FIXME: What to do?
+        unimplemented!();
+    }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -12,8 +12,8 @@ impl Serialize for NodeRef {
     fn serialize<S: Serializer>(&self, serializer: &mut S,
                                 traversal_scope: TraversalScope) -> Result<()> {
         match (traversal_scope, self.data()) {
-            (_, &NodeData::Element(ref element)) => {
-                if traversal_scope == IncludeNode {
+            (ref scope, &NodeData::Element(ref element)) => {
+                if *scope == IncludeNode {
                     try!(serializer.start_elem(
                         element.name.clone(),
                         element.attributes.borrow().map.iter().map(|(name, value)| (name, &**value))));
@@ -23,7 +23,7 @@ impl Serialize for NodeRef {
                     try!(Serialize::serialize(&child, serializer, IncludeNode));
                 }
 
-                if traversal_scope == IncludeNode {
+                if *scope == IncludeNode {
                     try!(serializer.end_elem(element.name.clone()));
                 }
                 Ok(())
@@ -37,7 +37,7 @@ impl Serialize for NodeRef {
                 Ok(())
             }
 
-            (ChildrenOnly, _) => Ok(()),
+            (ChildrenOnly(_), _) => Ok(()),
 
             (IncludeNode, &NodeData::Doctype(ref doctype)) => serializer.write_doctype(&doctype.name),
             (IncludeNode, &NodeData::Text(ref text)) => serializer.write_text(&text.borrow()),


### PR DESCRIPTION
Needed by rust-lang/rust#44884. `html5ever` 0.18.0 depends on `tendril` 0.3.1 which exhibits an undefined behavior by accessing a cell in a packed struct. This has been fixed in the latest version.

Unresolved: I'm not sure what to put into `parser::Sink::append_based_on_parent_node`.