### PR TITLE
Sort Attributes when serializing

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -17,11 +17,13 @@ impl Serialize for NodeRef {
                     let attrs = element.attributes.borrow();
 
                     // Unfortunately we need to allocate something to hold these &'a QualName
-                    let attrs = attrs.map.iter().map(|(name, attr)| {
+                    let mut attrs = attrs.map.iter().map(|(name, attr)| {
                         (QualName::new(
                             attr.prefix.clone(), name.ns.clone(), name.local.clone()
                         ), &attr.value)
                     }).collect::<Vec<_>>();
+
+                    attrs.sort_unstable();
 
                     serializer.start_elem(
                         element.name.clone(),


### PR DESCRIPTION
I've been making a crate that relies on parsing, modifying, and serializing HTML. Testing can become complex because I currently have to traverse two trees and compare elements as well as attributes.

This change makes serialization deterministic, making testing of the resulting string possible.