### PR TITLE
Change Attributes to a BTreeMap

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,15 +1,15 @@
 use html5ever::{LocalName, Prefix, Namespace};
-use std::collections::hash_map::{self, HashMap};
+use std::collections::btree_map::{BTreeMap, Entry};
 
-/// Convenience wrapper around a hashmap that adds method for attributes in the null namespace.
+/// Convenience wrapper around a btreemap that adds method for attributes in the null namespace.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Attributes {
     /// A map of attributes whose name can have namespaces.
-    pub map: HashMap<ExpandedName, Attribute>,
+    pub map: BTreeMap<ExpandedName, Attribute>,
 }
 
-/// https://www.w3.org/TR/REC-xml-names/#dt-expname
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+/// <https://www.w3.org/TR/REC-xml-names/#dt-expname>
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 pub struct ExpandedName {
     /// Namespace URL
     pub ns: Namespace,
@@ -37,33 +37,32 @@ pub struct Attribute {
 }
 
 impl Attributes {
-    /// Like HashMap::contains
+    /// Like BTreeMap::contains
     pub fn contains<A: Into<LocalName>>(&self, local_name: A) -> bool {
         self.map.contains_key(&ExpandedName::new(ns!(), local_name))
     }
 
-    /// Like HashMap::get
+    /// Like BTreeMap::get
     pub fn get<A: Into<LocalName>>(&self, local_name: A) -> Option<&str> {
         self.map.get(&ExpandedName::new(ns!(), local_name)).map(|attr| &*attr.value)
     }
 
-    /// Like HashMap::get_mut
+    /// Like BTreeMap::get_mut
     pub fn get_mut<A: Into<LocalName>>(&mut self, local_name: A) -> Option<&mut String> {
         self.map.get_mut(&ExpandedName::new(ns!(), local_name)).map(|attr| &mut attr.value)
     }
 
-    /// Like HashMap::entry
-    pub fn entry<A: Into<LocalName>>(&mut self, local_name: A)
-                                     -> hash_map::Entry<ExpandedName, Attribute> {
+    /// Like BTreeMap::entry
+    pub fn entry<A: Into<LocalName>>(&mut self, local_name: A) -> Entry<ExpandedName, Attribute> {
         self.map.entry(ExpandedName::new(ns!(), local_name))
     }
 
-    /// Like HashMap::insert
+    /// Like BTreeMap::insert
     pub fn insert<A: Into<LocalName>>(&mut self, local_name: A, value: String) -> Option<Attribute> {
         self.map.insert(ExpandedName::new(ns!(), local_name), Attribute { prefix: None, value })
     }
 
-    /// Like HashMap::remove
+    /// Like BTreeMap::remove
     pub fn remove<A: Into<LocalName>>(&mut self, local_name: A) -> Option<Attribute> {
         self.map.remove(&ExpandedName::new(ns!(), local_name))
     }


### PR DESCRIPTION
This change makes serialization deterministic, making testing of the resulting string possible.

This is essentially the same as #40, but is probably the correct way to do it.