### PR TITLE
Implement fragment parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod tree;
 
 pub use attributes::{Attribute, Attributes, ExpandedName};
 pub use node_data_ref::NodeDataRef;
-pub use parser::{parse_html, parse_html_with_options, ParseOpts, Sink};
+pub use parser::{parse_html, parse_html_with_options, parse_fragment, ParseOpts, Sink};
 pub use select::{Selector, Selectors, Specificity};
 pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,6 +37,24 @@ pub fn parse_html_with_options(opts: ParseOpts) -> html5ever::Parser<Sink> {
     html5ever::parse_document(sink, html5opts)
 }
 
+/// Parse an HTML fragment with html5ever and the default configuration.
+pub fn parse_fragment(ctx_name: QualName, ctx_attr: Vec<Attribute>) -> html5ever::Parser<Sink> {
+    parse_fragment_with_options(ParseOpts::default(), ctx_name, ctx_attr)
+}
+
+/// Parse an HTML fragment with html5ever with custom configuration.
+pub fn parse_fragment_with_options(opts: ParseOpts, ctx_name: QualName, ctx_attr: Vec<Attribute>) -> html5ever::Parser<Sink> {
+    let sink = Sink {
+        document_node: NodeRef::new_document(),
+        on_parse_error: opts.on_parse_error,
+    };
+    let html5opts = html5ever::ParseOpts {
+        tokenizer: opts.tokenizer,
+        tree_builder: opts.tree_builder,
+    };
+    html5ever::parse_fragment(sink, html5opts, ctx_name, ctx_attr)
+}
+
 /// Receives new tree nodes during parsing.
 pub struct Sink {
     document_node: NodeRef,

--- a/src/select.rs
+++ b/src/select.rs
@@ -9,8 +9,7 @@ use selectors::parser::SelectorParseErrorKind;
 use selectors::parser::{
     NonTSPseudoClass, Parser, Selector as GenericSelector, SelectorImpl, SelectorList,
 };
-use selectors::OpaqueElement;
-use selectors::{self, matching};
+use selectors::{self, matching, OpaqueElement};
 use std::fmt;
 use crate::tree::{ElementData, Node, NodeData, NodeRef};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,10 @@
 use html5ever::tree_builder::QuirksMode;
+use html5ever::QualName;
 use std::path::Path;
 
 use tempdir::TempDir;
 
-use crate::parser::parse_html;
+use crate::parser::{parse_html, parse_fragment};
 use crate::select::*;
 use crate::traits::*;
 
@@ -53,6 +54,16 @@ fn parse_and_serialize() {
         r"<!DOCTYPE html><html><head><title>Test case</title>
 </head><body><p>Content</p></body></html>"
     );
+}
+
+#[test]
+fn parse_and_serialize_fragment() {
+    let html = r"<tbody><tr><td>Test case";
+
+    let ctx_name = QualName::new(None, ns!(html), local_name!("tbody"));
+    let document = parse_fragment(ctx_name, vec![]).one(html);
+    assert_eq!(document.as_document().unwrap().quirks_mode(), QuirksMode::NoQuirks);
+    assert_eq!(document.to_string(), r"<html><tr><td>Test case</td></tr></html>");
 }
 
 #[test]


### PR DESCRIPTION
This pull request adds the following changes:
- Function `kuchiki::parse_fragment()`
- Function `kuchiki::parse_fragment_with_options()`
- Test `parse_and_serialize_fragment()`
- Remove `std::ascii::AsciiExt` from `src/select.rs`, use [inherent method instead](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.eq_ignore_ascii_case)
- Re-export `QualName` from `html5ever`

It would be nice to re-export the `ns!()` and `local_name!()` macros from `html5ever`. Unfortunately, from what I've read on the Rust issue tracker, that's not possible (yet). 

Also, I'll probably push some documentation in the near future.