### PR TITLE
Switch to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 description = "(朽木) HTML/XML tree manipulation library"
 repository = "https://github.com/SimonSapin/kuchiki"
+edition = "2018"
 
 [lib]
 name = "kuchiki"
@@ -12,8 +13,8 @@ doctest = false
 
 [dependencies]
 cssparser = "0.25"
-matches = "0.1.4"
-html5ever = "0.23"
+matches = "0.1.8"
+html5ever = "0.25"
 selectors = "0.21"
 
 [dev-dependencies]

--- a/examples/find_matches.rs
+++ b/examples/find_matches.rs
@@ -1,5 +1,3 @@
-extern crate kuchiki;
-
 use kuchiki::traits::*;
 
 fn main() {

--- a/examples/stack-overflow.rs
+++ b/examples/stack-overflow.rs
@@ -1,5 +1,3 @@
-extern crate kuchiki;
-
 fn main() {
     let mut depth = 2;
     // 20 M nodes is a few GB of memory.

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -57,7 +57,10 @@ impl Attributes {
     }
 
     /// Like BTreeMap::entry
-    pub fn entry<A: Into<LocalName>>(&mut self, local_name: A) -> Entry<ExpandedName, Attribute> {
+    pub fn entry<A: Into<LocalName>>(
+        &mut self,
+        local_name: A,
+    ) -> Entry<'_, ExpandedName, Attribute> {
         self.map.entry(ExpandedName::new(ns!(), local_name))
     }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,9 +4,9 @@ use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::iter::Rev;
 
-use node_data_ref::NodeDataRef;
-use select::Selectors;
-use tree::{ElementData, NodeRef};
+use crate::node_data_ref::NodeDataRef;
+use crate::select::Selectors;
+use crate::tree::{ElementData, NodeRef};
 
 impl NodeRef {
     /// Return an iterator of references to this node and its ancestors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,10 @@ Kuchiki (朽木), a HTML/XML tree manipulation library for Rust.
 
 #![deny(missing_docs)]
 
-extern crate cssparser;
 #[macro_use]
 extern crate html5ever;
 #[macro_use]
 extern crate matches;
-extern crate selectors;
-#[cfg(test)]
-extern crate tempdir;
 
 mod attributes;
 mod cell_extras;
@@ -26,11 +22,11 @@ mod serializer;
 mod tests;
 mod tree;
 
-pub use attributes::{Attribute, Attributes, ExpandedName};
-pub use node_data_ref::NodeDataRef;
-pub use parser::{parse_html, parse_html_with_options, ParseOpts};
-pub use select::{Selector, Selectors, Specificity};
-pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
+pub use crate::attributes::{Attribute, Attributes, ExpandedName};
+pub use crate::node_data_ref::NodeDataRef;
+pub use crate::parser::{parse_html, parse_html_with_options, ParseOpts};
+pub use crate::select::{Selector, Selectors, Specificity};
+pub use crate::tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 
 /// This module re-exports a number of traits that are useful when using Kuchiki.
 /// It can be used with:
@@ -39,6 +35,6 @@ pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 /// use kuchiki::traits::*;
 /// ```
 pub mod traits {
+    pub use crate::iter::{ElementIterator, NodeIterator};
     pub use html5ever::tendril::TendrilSink;
-    pub use iter::{ElementIterator, NodeIterator};
 }

--- a/src/node_data_ref.rs
+++ b/src/node_data_ref.rs
@@ -1,7 +1,7 @@
+use crate::tree::{Doctype, DocumentData, ElementData, Node, NodeRef};
 use std::cell::RefCell;
 use std::fmt;
 use std::ops::Deref;
-use tree::{Doctype, DocumentData, ElementData, Node, NodeRef};
 
 impl NodeRef {
     /// If this node is an element, return a strong reference to element-specific data.
@@ -103,7 +103,7 @@ impl<T> Clone for NodeDataRef<T> {
 
 impl<T: fmt::Debug> fmt::Debug for NodeDataRef<T> {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Debug::fmt(&**self, f)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,8 +3,8 @@ use html5ever::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::{self, Attribute, ExpandedName, QualName};
 use std::borrow::Cow;
 
-use attributes;
-use tree::NodeRef;
+use crate::attributes;
+use crate::tree::NodeRef;
 
 /// Options for the HTML parser.
 #[derive(Default)]

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,8 +1,9 @@
-use attributes::ExpandedName;
+use crate::attributes::ExpandedName;
+use crate::iter::{NodeIterator, Select};
+use crate::node_data_ref::NodeDataRef;
+use crate::tree::{ElementData, Node, NodeData, NodeRef};
 use cssparser::{self, CowRcStr, ParseError, SourceLocation, ToCss};
 use html5ever::{LocalName, Namespace};
-use iter::{NodeIterator, Select};
-use node_data_ref::NodeDataRef;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::context::QuirksMode;
 use selectors::parser::SelectorParseErrorKind;
@@ -12,7 +13,6 @@ use selectors::parser::{
 use selectors::OpaqueElement;
 use selectors::{self, matching};
 use std::fmt;
-use tree::{ElementData, Node, NodeData, NodeRef};
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 ///
@@ -263,7 +263,7 @@ impl selectors::Element for NodeDataRef<ElementData> {
     fn match_pseudo_element(
         &self,
         pseudo: &PseudoElement,
-        _context: &mut matching::MatchingContext<KuchikiSelectors>,
+        _context: &mut matching::MatchingContext<'_, KuchikiSelectors>,
     ) -> bool {
         match *pseudo {}
     }
@@ -271,7 +271,7 @@ impl selectors::Element for NodeDataRef<ElementData> {
     fn match_non_ts_pseudo_class<F>(
         &self,
         pseudo: &PseudoClass,
-        _context: &mut matching::MatchingContext<KuchikiSelectors>,
+        _context: &mut matching::MatchingContext<'_, KuchikiSelectors>,
         _flags_setter: &mut F,
     ) -> bool
     where
@@ -367,34 +367,34 @@ impl ::std::str::FromStr for Selectors {
 }
 
 impl fmt::Display for Selector {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.to_css(f)
     }
 }
 
 impl fmt::Display for Selectors {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut iter = self.0.iter();
         let first = iter
             .next()
             .expect("Empty Selectors, should contain at least one selector");
-        try!(first.0.to_css(f));
+        first.0.to_css(f)?;
         for selector in iter {
-            try!(f.write_str(", "));
-            try!(selector.0.to_css(f));
+            f.write_str(", ")?;
+            selector.0.to_css(f)?;
         }
         Ok(())
     }
 }
 
 impl fmt::Debug for Selector {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
 impl fmt::Debug for Selectors {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -6,7 +6,7 @@ use std::io::{Result, Write};
 use std::path::Path;
 use std::string::ToString;
 
-use tree::{NodeData, NodeRef};
+use crate::tree::{NodeData, NodeRef};
 
 impl Serialize for NodeRef {
     fn serialize<S: Serializer>(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 
 use tempdir::TempDir;
 
-use parser::parse_html;
-use select::*;
-use traits::*;
+use crate::parser::parse_html;
+use crate::select::*;
+use crate::traits::*;
 
 #[test]
 fn text_nodes() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,9 +5,9 @@ use std::fmt;
 use std::ops::Deref;
 use std::rc::{Rc, Weak};
 
-use attributes::{Attribute, Attributes, ExpandedName};
-use cell_extras::*;
-use iter::NodeIterator;
+use crate::attributes::{Attribute, Attributes, ExpandedName};
+use crate::cell_extras::*;
+use crate::iter::NodeIterator;
 
 /// Node data specific to the node type.
 #[derive(Debug, PartialEq, Clone)]
@@ -125,7 +125,7 @@ pub struct Node {
 
 impl fmt::Debug for Node {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{:?} @ {:?}", self.data, self as *const Node)
     }
 }


### PR DESCRIPTION
Basically upgrade dependencies and `cargo fix`.

Poorly cssparser can't be upgraded yet as we're waiting for a selectors crate release.