### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -17,7 +17,7 @@ use crate::tree::{ElementData, Node, NodeData, NodeRef};
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 ///
 /// Copied from rust-selectors.
-static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
+static SELECTOR_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r', '\x0C'];
 
 #[derive(Debug, Clone)]
 pub struct KuchikiSelectors;
@@ -287,9 +287,9 @@ impl selectors::Element for NodeDataRef<ElementData> {
                 .map
                 .iter()
                 .any(|(name, attr)| name.local == *local_name && operation.eval_str(&attr.value)),
-            NamespaceConstraint::Specific(ref ns_url) => attrs
+            NamespaceConstraint::Specific(ns_url) => attrs
                 .map
-                .get(&ExpandedName::new(ns_url.clone(), local_name.clone()))
+                .get(&ExpandedName::new(ns_url, local_name.clone()))
                 .map_or(false, |attr| operation.eval_str(&attr.value)),
         }
     }
@@ -367,7 +367,7 @@ impl Selectors {
         I: Iterator<Item = NodeDataRef<ElementData>>,
     {
         Select {
-            iter: iter,
+            iter,
             selectors: self,
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,8 +31,8 @@ fn text_nodes() {
     assert_eq!(&*texts[2].borrow(), " data");
     {
         let mut x = texts[0].borrow_mut();
-        &x.truncate(0);
-        &x.push_str("Content doesn't contain ");
+        x.truncate(0);
+        x.push_str("Content doesn't contain ");
     }
     assert_eq!(&*texts[0].borrow(), "Content doesn't contain ");
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -202,7 +202,7 @@ impl NodeRef {
             last_child: Cell::new(None),
             previous_sibling: Cell::new(None),
             next_sibling: Cell::new(None),
-            data: data,
+            data,
         }))
     }
 
@@ -218,7 +218,7 @@ impl NodeRef {
             } else {
                 None
             },
-            name: name,
+            name,
             attributes: RefCell::new(Attributes {
                 map: attributes.into_iter().collect(),
             }),


### PR DESCRIPTION
<details><summary>Previous warnings</summary>

```
warning: redundant field names in struct initialization
   --> src/select.rs:370:13
    |
370 |             iter: iter,
    |             ^^^^^^^^^^ help: replace it with: `iter`
    |
    = note: `#[warn(clippy::redundant_field_names)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/tree.rs:205:13
    |
205 |             data: data,
    |             ^^^^^^^^^^ help: replace it with: `data`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/tree.rs:221:13
    |
221 |             name: name,
    |             ^^^^^^^^^^ help: replace it with: `name`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: Statics have by default a `'static` lifetime
  --> src/select.rs:20:30
   |
20 | static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
   |                             -^^^^^^^------- help: consider removing `'static`: `&[char]`
   |
   = note: `#[warn(clippy::redundant_static_lifetimes)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes

error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
   --> src/select.rs:292:41
    |
292 |                 .get(&ExpandedName::new(ns_url.clone(), local_name.clone()))
    |                                         ^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::clone_double_ref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_double_ref
help: try dereferencing it
    |
292 |                 .get(&ExpandedName::new(&(*ns_url).clone(), local_name.clone()))
    |                                         ^^^^^^^^^^^^^^^^^^
help: or try being explicit about what type to clone
    |
292 |                 .get(&ExpandedName::new(&string_cache::atom::Atom<html5ever::NamespaceStaticSet>::clone(ns_url), local_name.clone()))
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error; 4 warnings emitted
```

</details>