### PR TITLE
parser: Allow callers to create their own sinks

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,8 +57,20 @@ pub fn parse_fragment_with_options(opts: ParseOpts, ctx_name: QualName, ctx_attr
 
 /// Receives new tree nodes during parsing.
 pub struct Sink {
-    document_node: NodeRef,
-    on_parse_error: Option<Box<dyn FnMut(Cow<'static, str>)>>,
+    /// The `Document` itself.
+    pub document_node: NodeRef,
+
+    /// The Sink will invoke this callback if it encounters a parse error.
+    pub on_parse_error: Option<Box<dyn FnMut(Cow<'static, str>)>>,
+}
+
+impl Default for Sink {
+    fn default() -> Sink {
+        Sink {
+            document_node: NodeRef::new_document(),
+            on_parse_error: None,
+        }
+    }
 }
 
 impl TreeSink for Sink {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -74,10 +74,10 @@ impl Default for Sink {
 }
 
 impl TreeSink for Sink {
-    type Output = NodeRef;
+    type Output = Self;
 
-    fn finish(self) -> NodeRef {
-        self.document_node
+    fn finish(self) -> Self {
+        self
     }
 
     type Handle = NodeRef;


### PR DESCRIPTION
This allows users to call parse_document with their own sink as follows:

    let sink = Sink::default();
    let parser = html5ever::parse_document(sink, ParseOpts::default())
    ...