### PR TITLE
add missing `!` to example's doctype

### DIFF
--- a/examples/find_matches.rs
+++ b/examples/find_matches.rs
@@ -4,7 +4,7 @@ use kuchiki::traits::*;
 
 fn main() {
     let html = r"
-        <DOCTYPE html>
+        <!DOCTYPE html>
         <html>
         <head></head>
         <body>


### PR DESCRIPTION
This doesn't impact the example at all, I'm just adding the doctype's missing `!` because I copied the example, modified it, and was confused about why my doc kept winding up in quirks mode.